### PR TITLE
[Security Solution] Security Assistant: take out the trash (icon)

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -37,6 +37,7 @@ import type { Message } from '../assistant_context/types';
 import { ConversationSelector } from './conversation_selector';
 import { PromptEditor } from './prompt_editor';
 import { getDefaultSystemPrompt, getSuperheroPrompt } from './prompt/helpers';
+import * as i18n from './translations';
 import type { Prompt } from './types';
 import { getPromptById } from './prompt_editor/helpers';
 import { QuickPrompts } from './quick_prompts/quick_prompts';
@@ -316,11 +317,11 @@ const AssistantComponent: React.FC<Props> = ({
           <ChatOptionsFlexItem grow={false}>
             <EuiFlexGroup direction="column" gutterSize="xs">
               <EuiFlexItem grow={false}>
-                <EuiToolTip position="right" content={'Clear chat'}>
+                <EuiToolTip position="right" content={i18n.CLEAR_CHAT}>
                   <EuiButtonIcon
                     display="base"
-                    iconType="trash"
-                    aria-label="Delete"
+                    iconType="cross"
+                    aria-label={i18n.CLEAR_CHAT}
                     color="danger"
                     onClick={() => {
                       setPromptTextPreview('');
@@ -332,11 +333,11 @@ const AssistantComponent: React.FC<Props> = ({
                 </EuiToolTip>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiToolTip position="right" content={'Submit message'}>
+                <EuiToolTip position="right" content={i18n.SUBMIT_MESSAGE}>
                   <EuiButtonIcon
                     display="base"
                     iconType="returnKey"
-                    aria-label="submit-message"
+                    aria-label={i18n.SUBMIT_MESSAGE}
                     color="primary"
                     onClick={handleButtonSendMessage}
                     isLoading={isLoading}

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/prompt_editor/selected_prompt_contexts/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/prompt_editor/selected_prompt_contexts/index.tsx
@@ -78,7 +78,7 @@ const SelectedPromptContextsComponent: React.FC<Props> = ({
           <EuiAccordion
             buttonContent={description}
             extraAction={
-              <EuiButtonIcon iconType="trash" onClick={() => unselectPromptContext(id)} />
+              <EuiButtonIcon iconType="cross" onClick={() => unselectPromptContext(id)} />
             }
             id={id}
             paddingSize="s"

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/prompt_editor/system_prompt/index.tsx
@@ -86,9 +86,16 @@ const SystemPromptComponent: React.FC<Props> = ({
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiToolTip content={i18n.ADD_SYSTEM_PROMPT_TOOLTIP} position="right">
+          <EuiToolTip
+            content={
+              showSelectSystemPrompt
+                ? i18n.CLEAR_SYSTEM_PROMPT_TOOLTIP
+                : i18n.ADD_SYSTEM_PROMPT_TOOLTIP
+            }
+            position="right"
+          >
             <EuiButtonIcon
-              iconType={showSelectSystemPrompt ? 'trash' : 'plus'}
+              iconType={showSelectSystemPrompt ? 'cross' : 'plus'}
               onClick={showSelectSystemPrompt ? clearSystemPrompt : onShowSelectSystemPrompt}
             />
           </EuiToolTip>
@@ -114,7 +121,7 @@ const SystemPromptComponent: React.FC<Props> = ({
 
           <EuiFlexItem grow={false}>
             <EuiToolTip content={i18n.CLEAR_SYSTEM_PROMPT_TOOLTIP} position="right">
-              <EuiButtonIcon iconType="trash" onClick={clearSystemPrompt} />
+              <EuiButtonIcon iconType="cross" onClick={clearSystemPrompt} />
             </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/translations.ts
@@ -7,6 +7,10 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const CLEAR_CHAT = i18n.translate('xpack.elasticAssistant.assistant.clearChat', {
+  defaultMessage: 'Clear chat',
+});
+
 export const DEFAULT_ASSISTANT_TITLE = i18n.translate(
   'xpack.elasticAssistant.assistant.defaultAssistantTitle',
   {
@@ -73,3 +77,7 @@ export const SETTINGS_PROMPT_HELP_TEXT_TITLE = i18n.translate(
     defaultMessage: 'Context provided before every conversations',
   }
 );
+
+export const SUBMIT_MESSAGE = i18n.translate('xpack.elasticAssistant.assistant.submitMessage', {
+  defaultMessage: 'Submit message',
+});


### PR DESCRIPTION
- replaces the `trash` icon with the `cross`